### PR TITLE
Add keychain access instructions for Root CA install

### DIFF
--- a/home/app/views/index/index.html.erb
+++ b/home/app/views/index/index.html.erb
@@ -116,6 +116,9 @@ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keyc
 
 				<h3>Or do it manually:</h3>
 				<p> Run the command <code>sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain new-root-certificate</code> with new-root-certificate replaced with the path to the downloaded CA.</p>
+				<br>
+				<h3>Or use Keychain Access:</h3>
+				<p>Open the <b>Keychain Access</b> app and drag the downloaded CA into the <i>Certificates</i> section</p>
 			</div>
    			<div class="tab-pane" id="ca-windows">
 				<h3>Run these commands(powershell):</h3>


### PR DESCRIPTION
for macos